### PR TITLE
MANTA-4428 rust-sharkspotter should put each object on a newline in default output file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ assert_cli = "0.6.0"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 clap = "2.33.0"
-libmanta = { git = "https://github.com/joyent/rust-libmanta" }
+libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.1.0" }
 moray = { git = "https://github.com/joyent/rust-moray"}
 slog = { version = "2.5.2" }
 slog-bunyan = { git = "https://github.com/kellymclaughlin/bunyan", branch = "build-on-smartos" }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,20 @@ OPTIONS:
     -s, --shark <STORAGE_ID>          Find objects that belong to this shark
 ```
 
+## Example
+```
+$ cargo run -- --domain east.joyent.us --shark 1.stor -M 1 -m 1
+$ json -f shard_1_1.stor.objs -g
+```
+
+__This can be a big file so [json](https://github.com/trentm/json) may struggle with it__
+
 ## Development
 
 Before integration run:
 ```
 cargo fmt
+cargo clippy
 ```
 
 and 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@ where
     );
 
     match mclient.sql(query.as_str(), vec![], r#"{"timeout": 10000}"#, |a| {
-        let id: String = serde_json::from_value(a[0][id_name].clone()).unwrap();
         query_handler(a, shard_num, handler)
     }) {
         Ok(()) => Ok(()),
@@ -112,7 +111,7 @@ where
 
 fn iter_ids<F>(
     id_name: &str,
-    moray_socket: &String,
+    moray_socket: &str,
     conf: &config::Config,
     log: Logger,
     shard_num: u32,
@@ -121,7 +120,7 @@ fn iter_ids<F>(
 where
     F: FnMut(MantaObject, u32) -> Result<(), Error>,
 {
-    let mut mclient = MorayClient::from_str(moray_socket.as_str(), log, None).unwrap();
+    let mut mclient = MorayClient::from_str(moray_socket, log, None).unwrap();
     let mut start_id = conf.begin;
     let mut end_id = conf.begin + conf.chunk_size - 1;
     let largest_id = match find_largest_id_value(&mut mclient, id_name) {
@@ -173,7 +172,11 @@ where
     Ok(())
 }
 
-pub fn run<F>(conf: &config::Config, log: Logger, mut handler: F) -> Result<(), Error>
+pub fn run<F>(
+    conf: &config::Config,
+    log: Logger,
+    mut handler: F,
+) -> Result<(), Error>
 where
     F: FnMut(MantaObject, u32) -> Result<(), Error>,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@
 
 extern crate sharkspotter;
 
-
-use slog::{o, Logger, Drain};
+use slog::{o, Drain, Logger};
 use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
@@ -49,6 +48,7 @@ fn main() -> Result<(), Error> {
         let file = file_map.get_mut(&shard).unwrap();
         let buf = serde_json::to_string(&mobj)?;
         file.write_all(buf.as_bytes())?; // TODO: match
+        file.write_all(b"\n")?;
 
         Ok(())
     })


### PR DESCRIPTION
Also:
MANTA-4492 pin rust-sharkspotter to rust-libmanta 0.1.0
and Tag: v0.1.0