### PR TITLE
MANTA-4904 rust-sharkspotter should pass back generic moray entry value instead of manta object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ assert_cli = "0.6.0"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 clap = "2.33.0"
-libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.6.0" }
-moray = { git = "https://github.com/joyent/rust-moray", tag="v0.8.0" }
+#libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.6.0" }
+libmanta = { git = "https://github.com/joyent/rust-libmanta", branch = "no_db_default" }
+#moray = { git = "https://github.com/joyent/rust-moray", tag="v0.8.0" }
+moray = { git = "https://github.com/joyent/rust-moray",  branch = "no_default_db"}
 slog = { version = "2.5.2" }
 slog-bunyan = { git = "https://github.com/kellymclaughlin/bunyan", branch = "build-on-smartos" }
 trust-dns-resolver = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sharkspotter"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Rui Loura <rui@joyent.com>", "Jon Anderson <jon.anderson@joyent.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ assert_cli = "0.6.0"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 clap = "2.33.0"
-#libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.6.0" }
-libmanta = { git = "https://github.com/joyent/rust-libmanta", branch = "no_db_default" }
-#moray = { git = "https://github.com/joyent/rust-moray", tag="v0.8.0" }
-moray = { git = "https://github.com/joyent/rust-moray",  branch = "no_default_db"}
+libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.7.0" }
+moray = { git = "https://github.com/joyent/rust-moray", tag="v0.9.0" }
 slog = { version = "2.5.2" }
 slog-bunyan = { git = "https://github.com/kellymclaughlin/bunyan", branch = "build-on-smartos" }
 trust-dns-resolver = "0.11.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,10 @@ impl Config {
             config.chunk_size = chunk_size;
         }
 
+        if let Ok(output_file) = value_t!(matches, "output_file", String) {
+            config.output_file = Some(output_file);
+        }
+
         config.domain = matches.value_of("domain").unwrap().to_string();
         config.shark = matches.value_of("shark").unwrap().to_string();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub chunk_size: u64,
     pub begin: u64,
     pub end: u64,
+    pub output_file: Option<String>,
 }
 
 impl Default for Config {
@@ -24,6 +25,7 @@ impl Default for Config {
             begin: 0,
             end: 0,
             chunk_size: 100,
+            output_file: None,
         }
     }
 }
@@ -81,6 +83,12 @@ impl Config {
                 .long("end")
                 .value_name("INDEX")
                 .help("index to stop scanning at (default: 0)")
+                .takes_value(true))
+            .arg(Arg::with_name("output_file")
+                .short("f")
+                .long("file")
+                .value_name("FILE_NAME")
+                .help("output filename (default shard_<num>_<shark>.objs")
                 .takes_value(true))
             .get_matches();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,35 +142,6 @@ where
             return _log_return_error(log, &e);
         }
     };
-    /*(
-    let _value: Value = match moray_value.get("_value") {
-        Some(val) => {
-            let val_clone = val.clone();
-            let str_val = match val_clone.as_str() {
-                Some(s) => s,
-                None => {
-                    let msg = format!("Could not format entry as string {:#?}",
-                                      val);
-                    return _log_return_error(log, &msg);
-                }
-            };
-
-            match serde_json::from_str(str_val) {
-                Ok(o) => o,
-                Err(e) => {
-                    let msg = format!("Could not format entry as object {:#?}",
-                                      val);
-                    return _log_return_error(log, &msg);
-                }
-            }
-        },
-        None => {
-            let msg =
-                format!("Missing '_value' in Moray entry {:#?}", moray_value);
-            return _log_return_error(log, &msg);
-        }
-    };
-    */
 
     let sharks: Vec<MantaObjectShark> = match _value.get("sharks") {
         Some(s) => {
@@ -194,22 +165,6 @@ where
             return _log_return_error(log, &msg);
         }
     };
-
-    /*
-    let manta_obj: MantaObject = match serde_json::from_value(
-        manta_value.clone())
-    {
-        Ok(mo) => mo,
-        Err(e) => {
-            let msg = format!(
-                "Could not deserialize manta value {:#?}. ({})",
-                manta_value,
-                e
-            );
-            return _log_return_error(log, &msg);
-        }
-    };
-    */
 
     // Filter on shark
     if !sharks.iter().any(|s| s.manta_storage_id == shark) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,22 +71,23 @@ pub fn manta_obj_from_moray_obj(moray_obj: &Value) -> Result<Value, String> {
             let str_val = match val_clone.as_str() {
                 Some(s) => s,
                 None => {
-                    return Err(format!("Could not format entry as string {:#?}",
-                        val));
+                    return Err(format!(
+                        "Could not format entry as string {:#?}",
+                        val
+                    ));
                 }
             };
 
             match serde_json::from_str(str_val) {
-                Ok(o) => o,
-                Err(e) => {
-                    return Err(format!("Could not format entry as object {:#?}",
-                        val));
-                }
+                Ok(o) => Ok(o),
+                Err(e) => Err(format!(
+                    "Could not format entry as object {:#?} ({})",
+                    val, e
+                )),
             }
-        },
+        }
         None => {
-            return Err(format!("Missing '_value' in Moray entry {:#?}",
-                moray_obj));
+            Err(format!("Missing '_value' in Moray entry {:#?}", moray_obj))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate clap;
 
 pub mod config;
 
-use libmanta::moray::{MantaObject, MantaObjectShark};
+use libmanta::moray::MantaObjectShark;
 use moray::client::MorayClient;
 use moray::objects as moray_objects;
 use serde::Deserialize;
@@ -75,14 +75,16 @@ fn query_handler<F>(
 where
     F: FnMut(Value, u32) -> Result<(), Error>,
 {
-
     match val.as_array() {
         Some(v) => {
             if v.len() > 1 {
-                warn!(log, "Expected 1 value, got {}.  Using first entry.",
-                      v.len());
+                warn!(
+                    log,
+                    "Expected 1 value, got {}.  Using first entry.",
+                    v.len()
+                );
             }
-        },
+        }
         None => {
             return _log_return_error(log, "Entry is not an array");
             /*
@@ -104,8 +106,7 @@ where
         Err(e) => {
             let msg = format!(
                 "Could not deserialize moray value {:#?}. ({})",
-                moray_value,
-                e
+                moray_value, e
             );
             return _log_return_error(log, &msg);
         }
@@ -114,10 +115,10 @@ where
     let _value = match moray_value.get("_value") {
         Some(val) => val,
         None => {
-            let msg = format!("Missing '_value' in Moray entry {:#?}",
-                moray_value);
+            let msg =
+                format!("Missing '_value' in Moray entry {:#?}", moray_value);
             return _log_return_error(log, &msg);
-        },
+        }
     };
 
     let sharks: Vec<MantaObjectShark> = match _value.get("sharks") {
@@ -131,11 +132,12 @@ where
                 Err(e) => {
                     let msg = format!(
                         "Could not deserialize sharks value {:#?}. ({})",
-                        s, e);
+                        s, e
+                    );
                     return _log_return_error(log, &msg);
                 }
             }
-        },
+        }
         None => {
             let msg = format!("Missing 'sharks' field {:#?}", _value);
             return _log_return_error(log, &msg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,16 @@ where
     };
 
     let _value = match moray_value.get("_value") {
-        Some(val) => val,
+        Some(val) => match val.as_object() {
+            Some(o) => o,
+            None => {
+                let msg = format!(
+                    "Could not format entry as object {:#?}",
+                    moray_value
+                );
+                return _log_return_error(log, &msg);
+            }
+        },
         None => {
             let msg =
                 format!("Missing '_value' in Moray entry {:#?}", moray_value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,15 +112,25 @@ where
         }
     };
 
-    let _value = match moray_value.get("_value") {
-        Some(val) => match val.as_object() {
-            Some(o) => o,
-            None => {
-                let msg = format!(
-                    "Could not format entry as object {:#?}",
-                    moray_value
-                );
-                return _log_return_error(log, &msg);
+    let _value: Value = match moray_value.get("_value") {
+        Some(val) => {
+            let val_clone = val.clone();
+            let str_val = match val_clone.as_str() {
+                Some(s) => s,
+                None => {
+                    let msg = format!("Could not format entry as string {:#?}",
+                                      val);
+                    return _log_return_error(log, &msg);
+                }
+            };
+
+            match serde_json::from_str(str_val) {
+                Ok(o) => o,
+                Err(e) => {
+                    let msg = format!("Could not format entry as object {:#?}",
+                                      val);
+                    return _log_return_error(log, &msg);
+                }
             }
         },
         None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ fn validate_shark(shark: &str, log: Logger, domain: &str) -> Result<(), Error> {
 /// Main entry point to for the sharkspotter library.  Callers need to
 /// provide a closure that takes a serde Value and a u32 shard number as its
 /// arguments.
-/// Sharkspotter works by first getting hte maximum and minimum _id and _idx
+/// Sharkspotter works by first getting the maximum and minimum _id and _idx
 /// for a given moray bucket (which is always "manta"), and then querying for
 /// entries in a user configurable chunk size.
 pub fn run<F>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,15 @@
 // Copyright 2019 Joyent, Inc.
 
+// Run sharkspotter as a commandline tool.
+//
+// By default sharkspotter will place all manta object metadata into a file
+// in json format.  The file will be of the form:
+//      shard_<shard_num>_<storage_id_number>.objs
+//
+// This file can be parsed with the `json` tool which allows users to filter
+// on json object certain fields.
+
+
 use serde_json::Value;
 use sharkspotter::config::Config;
 use slog::{o, Drain, Logger};

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn write_mobj_to_file(file: &mut File, moray_obj: Value) -> Result<(), Error> {
         Ok(mo) => mo,
         Err(e) => {
             eprintln!("{}", e);
-            return Ok(())
+            return Ok(());
         }
     };
 
@@ -36,8 +36,10 @@ fn write_mobj_to_file(file: &mut File, moray_obj: Value) -> Result<(), Error> {
         Some(oid) => match serde_json::to_string(oid) {
             Ok(o) => o,
             Err(e) => {
-                eprintln!("Could not deserialize objectId {:#?}, {}",
-                    manta_obj, e);
+                eprintln!(
+                    "Could not deserialize objectId {:#?}, {}",
+                    manta_obj, e
+                );
                 return Ok(());
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,15 @@ use std::process;
 use std::sync::Mutex;
 
 fn write_mobj_to_file(file: &mut File, moray_obj: Value) -> Result<(), Error> {
+    let manta_obj = match sharkspotter::manta_obj_from_moray_obj(&moray_obj) {
+        Ok(mo) => mo,
+        Err(e) => {
+            eprintln!("{}", e);
+            return Ok(())
+        }
+    };
+
+    /*
     let val: &Value = match moray_obj.get("_value") {
         Some(v) => v,
         None => {
@@ -20,24 +29,27 @@ fn write_mobj_to_file(file: &mut File, moray_obj: Value) -> Result<(), Error> {
             return Ok(());
         }
     };
+    */
 
-    let object_id = match val.get("objectId") {
+    //let object_id = match val.get("objectId") {
+    let object_id = match manta_obj.get("objectId") {
         Some(oid) => match serde_json::to_string(oid) {
             Ok(o) => o,
             Err(e) => {
-                eprintln!("Could not deserialize objectId {:#?}, {}", val, e);
+                eprintln!("Could not deserialize objectId {:#?}, {}",
+                    manta_obj, e);
                 return Ok(());
             }
         },
         None => {
-            eprintln!("Could not get objectId from value {:#?}", val);
+            eprintln!("Could not get objectId from value {:#?}", manta_obj);
             return Ok(());
         }
     };
 
     println!("{}", object_id);
 
-    let buf = serde_json::to_string(&val)?;
+    let buf = serde_json::to_string(&manta_obj)?;
     file.write_all(buf.as_bytes())?; // TODO: match
     file.write_all(b"\n")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,17 +21,6 @@ fn write_mobj_to_file(file: &mut File, moray_obj: Value) -> Result<(), Error> {
         }
     };
 
-    /*
-    let val: &Value = match moray_obj.get("_value") {
-        Some(v) => v,
-        None => {
-            eprintln!("Missing '_value' in Moray entry {:#?}", moray_obj);
-            return Ok(());
-        }
-    };
-    */
-
-    //let object_id = match val.get("objectId") {
     let object_id = match manta_obj.get("objectId") {
         Some(oid) => match serde_json::to_string(oid) {
             Ok(o) => o,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,6 +27,7 @@ OPTIONS:
     -e, --end <INDEX>                 index to stop scanning at (default: 0)
     -M, --max_shard <MAX_SHARD>       Ending shard number (default: 1)
     -m, --min_shard <MIN_SHARD>       Beginning shard number (default: 1)
+    -f, --file <FILE_NAME>            output filename (default shard_<num>_<shark>.objs
     -s, --shark <STORAGE_ID>          Find objects that belong to this shark";
 
         assert_cli::Assert::main_binary()


### PR DESCRIPTION
MANTA-4900 rust-sharkspotter should not require sqlite libraries to run
MANTA-4903 rust-sharkspotter should allow callers to specify an output file
