### PR TITLE
MANTA-4893 rust-sharkspotter should handle errors from moray server more gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.idea/
 *.iml
 Cargo.lock
+shard_*.objs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sharkspotter"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Rui Loura <rui@joyent.com>", "Jon Anderson <jon.anderson@joyent.com>"]
 edition = "2018"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub chunk_size: u64,
     pub begin: u64,
     pub end: u64,
+    pub skip_validate_shark: bool,
     pub output_file: Option<String>,
 }
 
@@ -25,6 +26,7 @@ impl Default for Config {
             begin: 0,
             end: 0,
             chunk_size: 100,
+            skip_validate_shark: false,
             output_file: None,
         }
     }
@@ -90,6 +92,11 @@ impl Config {
                 .value_name("FILE_NAME")
                 .help("output filename (default shard_<num>_<shark>.objs")
                 .takes_value(true))
+            .arg(Arg::with_name("skip_validate_shark")
+                .short("x")
+                .help("Skip shark validation. Useful if shark is in readonly \
+                mode")
+                .takes_value(false))
             .get_matches();
 
         let mut config = Config::default();
@@ -116,6 +123,10 @@ impl Config {
 
         if let Ok(output_file) = value_t!(matches, "output_file", String) {
             config.output_file = Some(output_file);
+        }
+
+        if matches.is_present("x") {
+            config.skip_validate_shark = true;
         }
 
         config.domain = matches.value_of("domain").unwrap().to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,9 @@ impl Config {
     // TODO:
     // Allow the option of selecting which data to keep
     pub fn from_args(_args: std::env::Args) -> Result<Config, Error> {
+        let version = env!("CARGO_PKG_VERSION");
         let matches = App::new("sharkspotter")
-            .version("0.1.0")
+            .version(version)
             .about("A tool for finding all of the Manta objects that reside on a given shark \
             (storage zone).")
             .setting(AppSettings::ArgRequiredElseHelp)
@@ -95,7 +96,7 @@ impl Config {
             .arg(Arg::with_name("skip_validate_shark")
                 .short("x")
                 .help("Skip shark validation. Useful if shark is in readonly \
-                mode")
+                mode.")
                 .takes_value(false))
             .get_matches();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ where
         };
         let moray_socket = format!("{}:{}", moray_ip, 2021);
 
-        for id in ["id", "_idx"].iter() {
+        for id in ["_id", "_idx"].iter() {
             if let Err(e) =
                 iter_ids(id, &moray_socket, &conf, log.clone(), i, &mut handler)
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@
 //   }
 // }
 
-
 #[macro_use]
 extern crate clap;
 
@@ -401,21 +400,37 @@ where
         conf.shark = new_shark;
     }
 
-    match validate_shark(&conf.shark, log.clone(), &conf.domain) {
-        Ok(()) => (),
-        Err(e) => {
-            error!(log, "{}", e);
-            return Err(e);
+    if !conf.skip_validate_shark {
+        match validate_shark(&conf.shark, log.clone(), &conf.domain) {
+            Ok(()) => (),
+            Err(e) => {
+                error!(log, "{}", e);
+                return Err(e);
+            }
         }
     }
 
     for i in conf.min_shard..=conf.max_shard {
         let moray_host = format!("{}.moray.{}", i, conf.domain);
-        let moray_ip = lookup_ip_str(moray_host.as_str())?;
+        let moray_ip = match lookup_ip_str(moray_host.as_str()) {
+            Ok(ip) => ip,
+            Err(e) => {
+                error!(
+                    &log,
+                    "Error looking up moray host, skipping shard. {:#?}", e
+                );
+                continue;
+            }
+        };
         let moray_socket = format!("{}:{}", moray_ip, 2021);
 
-        iter_ids("_id", &moray_socket, &conf, log.clone(), i, &mut handler)?;
-        iter_ids("_idx", &moray_socket, &conf, log.clone(), i, &mut handler)?;
+        for id in ["id", "_idx"].iter() {
+            if let Err(e) =
+                iter_ids(id, &moray_socket, &conf, log.clone(), i, &mut handler)
+            {
+                error!(&log, "Encountered error scanning shard {} ({})", i, e);
+            }
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@
 // This file can be parsed with the `json` tool which allows users to filter
 // on json object certain fields.
 
-
 use serde_json::Value;
 use sharkspotter::config::Config;
 use slog::{o, Drain, Logger};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -31,27 +31,6 @@ OPTIONS:
     -f, --file <FILE_NAME>            output filename (default shard_<num>_<shark>.objs
     -s, --shark <STORAGE_ID>          Find objects that belong to this shark
 ", env!("CARGO_PKG_VERSION"));
-        /*
-        const ERROR_STRING: &str = "sharkspotter 0.1.0
-A tool for finding all of the Manta objects that reside on a given shark (storage zone).
-
-USAGE:
-    sharkspotter [OPTIONS] --domain <MORAY_DOMAIN> --shark <STORAGE_ID>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -b, --begin <INDEX>               index to being scanning at (default: 0)
-    -c, --chunk-size <NUM_RECORDS>    number of records to scan per call to moray (default: 100)
-    -d, --domain <MORAY_DOMAIN>       Domain that the moray zones are in
-    -e, --end <INDEX>                 index to stop scanning at (default: 0)
-    -M, --max_shard <MAX_SHARD>       Ending shard number (default: 1)
-    -m, --min_shard <MIN_SHARD>       Beginning shard number (default: 1)
-    -f, --file <FILE_NAME>            output filename (default shard_<num>_<shark>.objs
-    -s, --shark <STORAGE_ID>          Find objects that belong to this shark";
-    */
 
         assert_cli::Assert::main_binary()
             .fails()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,6 +10,28 @@ mod integration {
 
     #[test]
     fn missing_all_args() {
+        let error_string = format!("sharkspotter {}
+A tool for finding all of the Manta objects that reside on a given shark (storage zone).
+
+USAGE:
+    sharkspotter [FLAGS] [OPTIONS] --domain <MORAY_DOMAIN> --shark <STORAGE_ID>
+
+FLAGS:
+    -h, --help       Prints help information
+    -x               Skip shark validation. Useful if shark is in readonly mode.
+    -V, --version    Prints version information
+
+OPTIONS:
+    -b, --begin <INDEX>               index to being scanning at (default: 0)
+    -c, --chunk-size <NUM_RECORDS>    number of records to scan per call to moray (default: 100)
+    -d, --domain <MORAY_DOMAIN>       Domain that the moray zones are in
+    -e, --end <INDEX>                 index to stop scanning at (default: 0)
+    -M, --max_shard <MAX_SHARD>       Ending shard number (default: 1)
+    -m, --min_shard <MIN_SHARD>       Beginning shard number (default: 1)
+    -f, --file <FILE_NAME>            output filename (default shard_<num>_<shark>.objs
+    -s, --shark <STORAGE_ID>          Find objects that belong to this shark
+", env!("CARGO_PKG_VERSION"));
+        /*
         const ERROR_STRING: &str = "sharkspotter 0.1.0
 A tool for finding all of the Manta objects that reside on a given shark (storage zone).
 
@@ -29,12 +51,13 @@ OPTIONS:
     -m, --min_shard <MIN_SHARD>       Beginning shard number (default: 1)
     -f, --file <FILE_NAME>            output filename (default shard_<num>_<shark>.objs
     -s, --shark <STORAGE_ID>          Find objects that belong to this shark";
+    */
 
         assert_cli::Assert::main_binary()
             .fails()
             .and()
             .stderr()
-            .contains(ERROR_STRING)
+            .contains(error_string.as_str())
             .unwrap();
     }
 


### PR DESCRIPTION
MANTA-4911 Allow sharkpotter to skip shark validation until MANTA-4462 is implemented
MANTA-4893 rust-sharkspotter should handle errors from moray server more gracefully