### PR TITLE
MANTA-5360 sharkspotter: add retry with exponentional backoff to call to iter_ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 assert_cli = "0.6.0"
+backoff = "0.1.5"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 clap = "2.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 assert_cli = "0.6.0"
-backoff = "0.1.5"
+backoff = "0.2.1"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 clap = "2.33.0"


### PR DESCRIPTION
Add exponential backoff to call to Iter_ids to better cope with errors seen in production. This change uses the backoff crate defaults (as of 0.2.1):

INITIAL_INTERVAL_MILLIS | The default initial interval value in milliseconds (0.5 seconds).
MAX_ELAPSED_TIME_MILLIS | The default maximum elapsed time in milliseconds (15 minutes).
MAX_INTERVAL_MILLIS | The default maximum back off time in milliseconds (1 minute).
MULTIPLIER | The default multiplier value (1.5 which is 50% increase per back off).
RANDOMIZATION_FACTOR | The default randomization factor (0.5 which results in a random period ranging between 50% below and 50% above the retry interval).


Unit tests pass:
```
running 2 tests
{"msg":"largest id value is unknown variant Bool(\n    false,\n)","v":0,"name":"sharkspotter","level":20test config::test::parse_args ... ok
,"time":"2020-08-04T22:02:41.900226744+00:00","hostname":"devzone2","pid":18878,"build-id":"0.15.0"}
{"msg":"Parsing largest id value as String","v":0,"name":"sharkspotter","level":20,"time":"2020-08-04T22:02:41.956496573+00:00","hostname":"devzone2","pid":18878,"build-id":"0.15.0"}
{"msg":"Parsing largest id value as String","v":0,"name":"sharkspotter","level":20,"time":"2020-08-04T22:02:41.956663398+00:00","hostname":"devzone2","pid":18878,"build-id":"0.15.0"}
{"msg":"Parsing largest id value as Number","v":0,"name":"sharkspotter","level":20,"time":"2020-08-04T22:02:41.956799615+00:00","hostname":"devzone2","pid":18878,"build-id":"0.15.0"}
test tests::_parse_max_id_value_test ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/sharkspotter-287d9e7b3c7aa93c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/integration-e8234e17f08a9f49

running 5 tests
test integration::invalid_arg ... ok
test integration::missing_domain ... ok
test integration::missing_all_required_args ... ok
test integration::missing_all_args ... ok
test integration::missing_shark ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests sharkspotter

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```